### PR TITLE
allow specifying mistty buffer name

### DIFF
--- a/mistty.el
+++ b/mistty.el
@@ -652,7 +652,7 @@ If OTHER-WINDOW is non-nil, put the buffer into another window."
       (error "No next mistty buffer"))))
 
 ;;;###autoload
-(defun mistty-create (&optional command other-window)
+(defun mistty-create (&optional command other-window buffer-name)
   "Create a new MisTTY buffer, running a shell.
 
 The shell that is run can be configured by setting
@@ -666,7 +666,7 @@ If OTHER-WINDOW is non-nil, put the buffer into another window.
 
 Upon success, the function returns  the newly-created buffer."
   (interactive)
-  (let ((buf (generate-new-buffer "*mistty*")))
+  (let ((buf (generate-new-buffer (or buffer-name "*mistty*"))))
     (if other-window
         (switch-to-buffer-other-window buf)
       (switch-to-buffer buf))
@@ -679,7 +679,7 @@ Upon success, the function returns  the newly-created buffer."
       buf)))
 
 ;;;###autoload
-(defun mistty-create-other-window (&optional command)
+(defun mistty-create-other-window (&optional command buffer-name)
   "Create a new MisTTY buffer, running a shell, in another window.
 
 COMMAND, if specified, is the command to execute instead of the
@@ -687,7 +687,7 @@ shell.
 
 See the documentation of `mistty-create' for details."
   (interactive)
-  (mistty-create command 'other-window))
+  (mistty-create command 'other-window buffer-name))
 
 (defun mistty--process-sentinel (proc msg)
   "Process sentinel for MisTTY shell processes.


### PR DESCRIPTION
really cool package! i'm trying it out as a replacement for how i use `vterm` and it's going well so far.

i like to have one main term-ish buffer per project (git repo). i do this with a custom defun in my `.emacs.d` that allows me to find or create a buffer based on the default directory of the current project root. currently i can't easily do this as `mistty-create` always generates a buffer named `*mistty*`. after this change, i'm able to rewrite my custom defun using `project.el` as:

```elisp
(defun project-mistty ()
  (interactive)
  (let* ((default-directory (project-root (project-current t)))
         (default-project-mistty-name (project-prefixed-buffer-name "mistty"))
         (mistty-buffer (get-buffer default-project-mistty-name)))
    (if (and mistty-buffer (not current-prefix-arg))
        (pop-to-buffer mistty-buffer display-comint-buffer-action)
      (mistty-create nil nil (generate-new-buffer-name default-project-mistty-name)))))
```

this PR was just the easiest way to accommodate for this. if you have a different implementation idea, please feel free to override this change, but i think it might be good to allow customizing the buffer name so one can more easily pop to specific mistty buffers.